### PR TITLE
fix: pass model via claude_args for claude-code-action

### DIFF
--- a/.github/workflows/repo-health-scanner-claude.yml
+++ b/.github/workflows/repo-health-scanner-claude.yml
@@ -33,7 +33,6 @@ jobs:
         id: scanner
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-opus-4-6
           prompt: |
             REPO: ${{ github.repository }}
 
@@ -117,7 +116,7 @@ jobs:
             - Any deferred items needing manual attention
 
           claude_args: |
-            --allowedTools "Read,Write,Edit,Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(pip:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(grep:*),Bash(jq:*)"
+            --model claude-opus-4-6 --allowedTools "Read,Write,Edit,Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(pip:*),Bash(find:*),Bash(cat:*),Bash(ls:*),Bash(grep:*),Bash(jq:*)"
 
       - name: Save scan cache
         if: always()


### PR DESCRIPTION
The `model` input is not a valid parameter for `anthropics/claude-code-action@v1`. This caused the workflow to crash immediately with an SDK error.

**Fix:** Move model selection from the invalid `model:` input to `claude_args: '--model claude-opus-4-6'`.