### PR TITLE
Add show_full_output to repo health scanner

### DIFF
--- a/.github/workflows/repo-health-scanner-claude.yml
+++ b/.github/workflows/repo-health-scanner-claude.yml
@@ -33,6 +33,7 @@ jobs:
         id: scanner
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
 


### PR DESCRIPTION
## Summary
- Enable `show_full_output: true` for `anthropics/claude-code-action@v1` in the repo health scanner workflow
- This makes Claude Code's full output visible in workflow logs, which is useful for debugging failures (e.g., authentication errors, SDK crashes)

## Context
Without this flag, the action hides detailed output for security. With it enabled, error messages like `Invalid API key` are clearly visible instead of being masked behind minified SDK stack traces.