### PR TITLE
Sync repo health scanner with ml-training-pipelines

### DIFF
--- a/.github/workflows/repo-health-scanner-claude.yml
+++ b/.github/workflows/repo-health-scanner-claude.yml
@@ -2,7 +2,7 @@ name: Repo Health Scanner (Claude Code Action)
 
 on:
   schedule:
-    - cron: "33 8 * * 3" # Weekly on Wednesday (scattered time)
+    - cron: "0 22 * * 0" # Every Monday 8am AEST (9am AEDT)
   workflow_dispatch:
 
 permissions:
@@ -19,6 +19,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Close stale repo-health PRs (idle > 14 days)
+        run: |
+          gh pr list --label "repo-health" --state open --json number,updatedAt --jq '
+            .[] | select(
+              (now - (.updatedAt | fromdateiso8601)) > (14 * 24 * 3600)
+            ) | .number
+          ' | while read -r pr; do
+            echo "Closing stale PR #$pr"
+            gh pr close "$pr" --comment "Auto-closed: idle for more than 14 days. A new scan will create fresh PRs if issues persist."
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Restore scan cache
         id: cache
@@ -63,10 +76,13 @@ jobs:
 
             Detect the project's dependency files dynamically. Look for:
             - requirements.txt, pyproject.toml, setup.py, Pipfile (Python)
-            - package.json, yarn.lock, pnpm-lock.yaml (Node.js)
+            - package.json, yarn.lock, pnpm-lock.yaml (Node.js/TypeScript)
+            - tsconfig.json (TypeScript)
             - go.mod (Go)
             - Gemfile (Ruby)
             - Cargo.toml (Rust)
+            - build.sbt, build.sc (Scala - sbt/Mill)
+            - pom.xml, build.gradle, build.gradle.kts (Java/Kotlin/Scala - Maven/Gradle)
             - Dockerfile, docker-compose.yml (Docker base image versions)
             - .github/dependabot.yml (Dependabot config completeness)
 


### PR DESCRIPTION
## Summary

Syncs the repo health scanner workflow with the latest version from `zendesk/ml-training-pipelines` (PR #128), adapted for a personal repo (direct Anthropic API key instead of Bedrock).

## Changes

- **Schedule**: Monday 8am AEST (9am AEDT) instead of Wednesday
- **Stale PR cleanup**: Auto-closes `repo-health` PRs idle for >14 days
- **More languages**: Added TypeScript, Scala (sbt/Mill), Java/Kotlin (Maven/Gradle)
- **Auth**: Direct `ANTHROPIC_API_KEY` secret (get from https://console.anthropic.com/settings/keys)
- **Model**: Claude Opus 4.6 via `claude_args`

## Setup

Set a valid Anthropic API key (starts with `sk-ant-`):
```bash
gh secret set ANTHROPIC_API_KEY --repo xuqun123/dependabot-demo
```

Then trigger via Actions tab → "Repo Health Scanner (Claude Code Action)" → "Run workflow"